### PR TITLE
Fix slide UI bugs and improve mobile view

### DIFF
--- a/static/slide/inspector.js
+++ b/static/slide/inspector.js
@@ -487,42 +487,7 @@ class InspectorManager {
 
     _setupColorPickerTrigger(containerId, config) {
         const container = document.getElementById(containerId);
-        if (!container) return;
-
-        // 見た目をカラーボックスのようにする
-        container.classList.add('color-picker-trigger');
-        const colorDisplay = document.createElement('div');
-        // initialColorがグラデーション文字列の場合も考慮
-        colorDisplay.style.background = config.initialColor;
-        container.innerHTML = ''; // 中身をクリア
-        container.appendChild(colorDisplay);
-
-        if (config.disabled) {
-            container.style.pointerEvents = 'none';
-            container.style.opacity = '0.5';
-            return;
-        }
-
-        container.onclick = (e) => {
-            const pickerId = `color-picker-window-${containerId}`;
-            let picker = this.colorPickers[pickerId];
-
-            if (!picker) {
-                picker = new ColorPicker(pickerId, config.initialColor, config.callback, {
-                    paletteKey: config.paletteKey,
-                    title: config.title,
-                    showEyedropper: true,
-                    showReset: true,
-                    defaultColor: config.initialColor
-                });
-                this.colorPickers[pickerId] = picker;
-            } else {
-                picker.setColor(config.initialColor);
-                picker.onChangeCallback = config.callback; // コールバックを最新に更新
-            }
-            
-            picker.show(e.clientX, e.clientY);
-        };
+        this.app._setupColorPickerTrigger(container, config);
     }
 
     _updateElementStyle(selectedElement, prop, value) {

--- a/static/slide/slide.css
+++ b/static/slide/slide.css
@@ -613,6 +613,25 @@
     #sidebar-content.active {
         transform: translateY(0%);
     }
+
+    /* --- Mobile Responsive Grid Adjustments --- */
+    #element-add-buttons-container,
+    .pos-size-grid {
+        grid-template-columns: 1fr;
+    }
+
+    #qr-modal .qr-grid,
+    #chart-modal .chart-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+
+    .color-inputs {
+        flex-wrap: wrap;
+    }
+    .color-inputs input {
+        flex-basis: 100%;
+    }
 }
 
 #toolbar button {


### PR DESCRIPTION
This commit addresses two main UI issues in the slide editor:

1.  The color picker for the page background was incorrectly displayed by default. This was fixed by refactoring the initialization to use a pop-up trigger, consistent with other color pickers in the application.

2.  The UI was difficult to use on mobile devices. Several multi-column layouts in the sidebar panels and modals have been made responsive, stacking into a single column on narrow screens to improve usability.